### PR TITLE
Update SmallCapTrader docs and fix i18n link routing

### DIFF
--- a/src/components/DocSidebar.astro
+++ b/src/components/DocSidebar.astro
@@ -1,4 +1,6 @@
 ---
+import { getLangFromUrl, getLocalePath } from '../i18n/utils';
+
 interface NavChild {
   label: string;
   href: string;
@@ -16,10 +18,15 @@ interface Props {
 }
 
 const { title, items } = Astro.props;
+const lang = getLangFromUrl(Astro.url);
 const currentPath = Astro.url.pathname.replace(/\/$/, '');
 
+function localize(href: string): string {
+  return getLocalePath(href, lang);
+}
+
 function isActive(href: string): boolean {
-  return currentPath === href;
+  return currentPath === localize(href);
 }
 ---
 
@@ -35,7 +42,7 @@ function isActive(href: string): boolean {
               {item.children.map((child) => (
                 <li>
                   <a
-                    href={`${child.href}/`}
+                    href={`${localize(child.href)}/`}
                     class:list={['doc-nav-link', 'doc-nav-sublink', { active: isActive(child.href) }]}
                     aria-current={isActive(child.href) ? 'page' : undefined}
                   >
@@ -48,7 +55,7 @@ function isActive(href: string): boolean {
         ) : (
           <li>
             <a
-              href={`${item.href}/`}
+              href={`${localize(item.href!)}/`}
               class:list={['doc-nav-link', { active: isActive(item.href!) }]}
               aria-current={isActive(item.href!) ? 'page' : undefined}
             >

--- a/src/components/ProjectCard.astro
+++ b/src/components/ProjectCard.astro
@@ -1,6 +1,6 @@
 ---
 import TechBadge from './TechBadge.astro';
-import { getLangFromUrl, useTranslations } from '../i18n/utils';
+import { getLangFromUrl, useTranslations, getLocalePath } from '../i18n/utils';
 
 interface Props {
   title: string;
@@ -22,7 +22,7 @@ const t = useTranslations(lang);
     {tech.map((t) => <TechBadge name={t} />)}
   </div>
   <div class="card-links">
-    <a href={link} class="card-link">
+    <a href={getLocalePath(link, lang)} class="card-link">
       {t('projects.viewProject')}
       <span aria-hidden="true">&rarr;</span>
     </a>

--- a/src/components/Timeline.astro
+++ b/src/components/Timeline.astro
@@ -1,5 +1,5 @@
 ---
-import { getLangFromUrl, useTranslations } from '../i18n/utils';
+import { getLangFromUrl, useTranslations, getLocalePath } from '../i18n/utils';
 
 interface TimelineEntry {
   date: string;
@@ -32,7 +32,7 @@ const t = useTranslations(lang);
           {entry.description.map((bullet) => <li>{bullet}</li>)}
         </ul>
         {entry.projectLink && (
-          <a href={entry.projectLink} class="timeline-link">
+          <a href={getLocalePath(entry.projectLink, lang)} class="timeline-link">
             {entry.projectLink === '/projects/' ? t('experience.viewProjects') : t('experience.viewProject')}
             <span aria-hidden="true">&rarr;</span>
           </a>

--- a/src/content/projects/smallcaptrader/architecture.md
+++ b/src/content/projects/smallcaptrader/architecture.md
@@ -31,6 +31,7 @@ Horizontally scalable architecture. Symbol-range partitioning via Redis pub/sub.
 | **sct-stream-router** | 1 | Parses market data WebSocket, routes by symbol range to Redis channels |
 | **sct-shard-worker** | N | Runs all strategies for assigned symbol range |
 | **sct-tick-recorder** | 1 | Writes all ticks to QuestDB for backtesting replay |
+| **sct-backtest-worker** | N | Distributed backtest and rule mining execution |
 | **sct-worker** | 1 | Signal consumer + trade execution + position monitoring |
 
 ### Data Flow
@@ -78,6 +79,8 @@ Stream Router ─── parses trades/bars
 | **Validation** | Pydantic v2 | Field validators, settings management |
 | **Linting** | Ruff | Unified tool (black + flake8 + isort) |
 | **Logging** | structlog | Structured JSON, async-safe |
+| **Data Processing** | Polars, Pandas, NumPy | High-performance analytics |
+| **CLI** | Typer + Rich | Administrative tooling |
 | **Observability** | OpenTelemetry + Prometheus | Distributed tracing, metrics |
 
 ### Frontend Stack

--- a/src/content/projects/smallcaptrader/components.md
+++ b/src/content/projects/smallcaptrader/components.md
@@ -30,6 +30,7 @@ When multiple strategies fire on the same symbol simultaneously:
 - Cross-strategy correlation analytics prevent redundant overlapping trades
 - Each signal includes confidence score and strategy metadata
 - Per-strategy risk parameters control position sizing and exposure
+- Detection-type filtering ensures strategies only fire on matching stock behavior (fast, slow, or both)
 
 ---
 
@@ -65,6 +66,19 @@ Discovered rules follow a defined promotion path:
 
 ---
 
+## Exit Engine
+
+Centralized exit logic shared across all strategies and promoted rules:
+
+- **Stop Loss** — Fixed percentage-based stop loss
+- **Trailing Stop** — Dynamic stop that follows price movement
+- **Scaled Profit Targets** — Multi-tier partial profit taking at configurable levels
+- **Time-Based Exits** — Maximum hold duration enforcement
+
+Each strategy and promoted rule can define its own exit configuration, enabling fine-grained risk management without global fallback behavior.
+
+---
+
 ## Broker Interface
 
 Abstract `BaseBroker` interface enables seamless switching via configuration.
@@ -97,11 +111,21 @@ Abstract `BaseBroker` interface enables seamless switching via configuration.
 Distributed backtesting with parameter optimization:
 
 - Sweeps parameter combinations across all strategies in parallel
+- Dedicated backtest workers in sharded mode for distributed execution via Redis work queues
 - Tick data replay from QuestDB enables high-fidelity backtesting against historical market conditions
 - Results stored with per-strategy analytics
 - Best-performing configurations can be applied to live trading
 - Real-time progress streaming via WebSocket to the frontend dashboard
-- Campaign infrastructure supports automated multi-day discovery and optimization runs
+
+### Campaign Backtesting
+
+Multi-day strategy comparison infrastructure:
+
+- Aggregates performance across arbitrary date ranges in a single operation
+- Per-date data pre-caching for worker efficiency
+- Cross-day aggregation surfaces strategy consistency and parameter stability
+- Partial failure handling — campaigns continue if individual dates fail
+- Supports multiple discovery modes for different market behavior types
 
 ---
 
@@ -117,7 +141,8 @@ Distributed backtesting with parameter optimization:
 | **Analytics** | Performance charts, equity curves, breakdown by rule and strategy |
 | **Backtest** | Run backtests, real-time progress, per-strategy analytics |
 | **Auto-Backtest** | Parameter optimization iterations, best-params storage |
-| **Strategy Discovery** | Rule mining UI, temporal pattern visualization, promote rules to live |
+| **Campaign Backtest** | Multi-day strategy comparison, per-day drill-down, cross-day aggregation |
+| **Strategy Discovery** | Rule mining UI, temporal pattern visualization, promote rules with detection-type tagging |
 | **Settings** | Risk management, notifications, broker config, scheduler |
 
 ---
@@ -144,3 +169,18 @@ Distributed backtesting with parameter optimization:
 | Table | Purpose |
 |-------|---------|
 | `discovered_rules` | Mined rules with conditions, exit config, score, live status |
+
+---
+
+## Authentication & Security
+
+- JWT-based authentication with access and refresh tokens
+- Extended session support for persistent dashboard access
+- Protected API routes requiring bearer tokens
+- PDT (Pattern Day Trader) compliance tracking
+
+---
+
+## CLI Tooling
+
+Administrative command-line interface built with Typer and Rich for database management, service control, and operational tasks.

--- a/src/content/projects/smallcaptrader/de/architecture.md
+++ b/src/content/projects/smallcaptrader/de/architecture.md
@@ -31,6 +31,7 @@ Horizontal skalierbare Architektur. Symbol-Range-Partitionierung via Redis Pub/S
 | **sct-stream-router** | 1 | Parst Marktdaten-WebSocket, routet nach Symbol-Range an Redis-Kanäle |
 | **sct-shard-worker** | N | Führt alle Strategien für zugewiesenen Symbol-Range aus |
 | **sct-tick-recorder** | 1 | Schreibt alle Ticks nach QuestDB für Backtest-Replay |
+| **sct-backtest-worker** | N | Verteilte Backtest- und Rule-Mining-Ausführung |
 | **sct-worker** | 1 | Signal-Consumer + Trade-Ausführung + Positions-Monitoring |
 
 ### Datenfluss
@@ -78,6 +79,8 @@ Stream Router ─── parses trades/bars
 | **Validierung** | Pydantic v2 | Field Validators, Settings Management |
 | **Linting** | Ruff | Vereinheitlichtes Tool (black + flake8 + isort) |
 | **Logging** | structlog | Strukturiertes JSON, async-sicher |
+| **Datenverarbeitung** | Polars, Pandas, NumPy | Hochperformante Analytik |
+| **CLI** | Typer + Rich | Administrative Werkzeuge |
 | **Observability** | OpenTelemetry + Prometheus | Distributed Tracing, Metriken |
 
 ### Frontend-Stack

--- a/src/content/projects/smallcaptrader/de/components.md
+++ b/src/content/projects/smallcaptrader/de/components.md
@@ -30,6 +30,7 @@ Wenn mehrere Strategien gleichzeitig für dasselbe Symbol auslösen:
 - Strategieübergreifende Korrelationsanalyse verhindert redundante überlappende Trades
 - Jedes Signal enthält einen Konfidenz-Score und Strategie-Metadaten
 - Per-Strategie-Risikoparameter steuern Positionsgrösse und Exposure
+- Erkennungstyp-Filterung stellt sicher, dass Strategien nur bei passendem Aktienverhalten feuern (schnell, langsam oder beides)
 
 ---
 
@@ -65,6 +66,19 @@ Entdeckte Regeln folgen einem definierten Beförderungspfad:
 
 ---
 
+## Exit Engine
+
+Zentralisierte Exit-Logik, die über alle Strategien und beförderte Regeln geteilt wird:
+
+- **Stop Loss** — Fester prozentualer Stop Loss
+- **Trailing Stop** — Dynamischer Stop, der der Preisbewegung folgt
+- **Skalierte Gewinnziele** — Mehrstufige Teilgewinnmitnahme auf konfigurierbaren Niveaus
+- **Zeitbasierte Exits** — Maximale Haltedauer-Durchsetzung
+
+Jede Strategie und beförderte Regel kann ihre eigene Exit-Konfiguration definieren, was feingranulares Risikomanagement ohne globales Fallback-Verhalten ermöglicht.
+
+---
+
 ## Broker-Schnittstelle
 
 Abstraktes `BaseBroker`-Interface ermöglicht nahtlosen Wechsel via Konfiguration.
@@ -97,11 +111,21 @@ Abstraktes `BaseBroker`-Interface ermöglicht nahtlosen Wechsel via Konfiguratio
 Verteiltes Backtesting mit Parameteroptimierung:
 
 - Durchläuft Parameterkombinationen über alle Strategien parallel
+- Dedizierte Backtest-Worker im Sharded-Modus für verteilte Ausführung via Redis Work Queues
 - Tick-Daten-Replay aus QuestDB ermöglicht High-Fidelity-Backtesting gegen historische Marktbedingungen
 - Ergebnisse mit Per-Strategie-Analysen gespeichert
 - Bestperformende Konfigurationen können auf Live-Trading angewandt werden
 - Echtzeit-Fortschrittsstreaming via WebSocket zum Frontend-Dashboard
-- Kampagnen-Infrastruktur unterstützt automatisierte mehrtägige Entdeckungs- und Optimierungsläufe
+
+### Kampagnen-Backtesting
+
+Mehrtägige Strategievergleichs-Infrastruktur:
+
+- Aggregiert Performance über beliebige Datumsbereiche in einem einzelnen Vorgang
+- Per-Datum-Daten-Precaching für Worker-Effizienz
+- Tagesübergreifende Aggregation zeigt Strategiekonsistenz und Parameterstabilität
+- Teilfehler-Behandlung — Kampagnen laufen weiter, wenn einzelne Tage fehlschlagen
+- Unterstützt mehrere Discovery-Modi für verschiedene Marktverhaltentypen
 
 ---
 
@@ -117,7 +141,8 @@ Verteiltes Backtesting mit Parameteroptimierung:
 | **Analytics** | Performance-Charts, Equity-Kurven, Aufschlüsselung nach Regel und Strategie |
 | **Backtest** | Backtests durchführen, Echtzeit-Fortschritt, Per-Strategie-Analysen |
 | **Auto-Backtest** | Parameteroptimierungs-Iterationen, Best-Params-Speicherung |
-| **Strategy Discovery** | Rule Mining UI, temporale Mustervisualisierung, Regeln live schalten |
+| **Campaign Backtest** | Mehrtägiger Strategievergleich, Per-Tag-Drill-Down, tagesübergreifende Aggregation |
+| **Strategy Discovery** | Rule Mining UI, temporale Mustervisualisierung, Regelbeförderung mit Erkennungstyp-Tagging |
 | **Settings** | Risikomanagement, Benachrichtigungen, Broker-Konfiguration, Scheduler |
 
 ---
@@ -144,3 +169,18 @@ Verteiltes Backtesting mit Parameteroptimierung:
 | Tabelle | Zweck |
 |---------|-------|
 | `discovered_rules` | Gefundene Regeln mit Bedingungen, Exit-Konfiguration, Score, Live-Status |
+
+---
+
+## Authentifizierung & Sicherheit
+
+- JWT-basierte Authentifizierung mit Access- und Refresh-Tokens
+- Erweiterte Sitzungsunterstützung für persistenten Dashboard-Zugang
+- Geschützte API-Routen mit Bearer-Token-Anforderung
+- PDT (Pattern Day Trader) Compliance-Tracking
+
+---
+
+## CLI-Werkzeuge
+
+Administrative Kommandozeilen-Schnittstelle auf Basis von Typer und Rich für Datenbankverwaltung, Service-Steuerung und operationelle Aufgaben.

--- a/src/pages/en/projects/smallcaptrader/index.astro
+++ b/src/pages/en/projects/smallcaptrader/index.astro
@@ -99,8 +99,9 @@ const tech = ['Python', 'FastAPI', 'Next.js', 'React', 'TypeScript', 'PostgreSQL
         <li><strong>Discovered Rules</strong> — Auto-mined strategies from the rule-mining engine, promoted to live trading after validation</li>
       </ul>
       <p>
-        Each strategy includes configurable risk parameters, signal confidence scoring, and priority-based
-        arbitration when multiple strategies fire simultaneously on the same symbol.
+        Each strategy includes configurable risk parameters, signal confidence scoring, priority-based
+        arbitration when multiple strategies fire simultaneously on the same symbol, and detection-type
+        filtering so strategies only activate on matching stock behavior (fast-moving, slow-moving, or both).
       </p>
     </section>
 
@@ -141,6 +142,33 @@ const tech = ['Python', 'FastAPI', 'Next.js', 'React', 'TypeScript', 'PostgreSQL
       </div>
 
       <div class="decision">
+        <h3>Unified Exit Engine</h3>
+        <p>
+          Centralized exit logic handling stop loss, trailing stops, scaled profit targets, and
+          time-based exits. Each strategy and promoted rule can define its own exit configuration,
+          enabling fine-grained risk management without global fallback behavior.
+        </p>
+      </div>
+
+      <div class="decision">
+        <h3>Campaign Backtesting</h3>
+        <p>
+          Multi-day strategy comparison infrastructure that aggregates performance across arbitrary
+          date ranges. Distributed execution via Redis work queues with per-date data pre-caching.
+          Cross-day aggregation surfaces strategy consistency, win-day counts, and parameter stability
+          over extended periods.
+        </p>
+      </div>
+
+      <div class="decision">
+        <h3>Authentication & Security</h3>
+        <p>
+          JWT-based authentication with access and refresh tokens. Protected API routes require
+          bearer tokens. Extended session support for persistent dashboard access.
+        </p>
+      </div>
+
+      <div class="decision">
         <h3>Observability Stack</h3>
         <p>
           Structured JSON logging via structlog, distributed tracing with OpenTelemetry, and
@@ -155,8 +183,11 @@ const tech = ['Python', 'FastAPI', 'Next.js', 'React', 'TypeScript', 'PostgreSQL
       <p>
         Next.js 16 dashboard with React 19, Tailwind CSS v4, and shadcn/ui components. TanStack
         Query for server state management. Key pages include real-time portfolio monitoring, order
-        entry, strategy configuration, backtest analytics with equity curves, and a strategy
-        discovery interface for visualizing and promoting mined rules.
+        entry, strategy configuration with independent fast/slow detection toggles, backtest analytics
+        with equity curves, campaign backtesting for multi-day comparison, and a strategy discovery
+        interface for visualizing and promoting mined rules with detection-type tagging. The backend
+        also includes a CLI built with Typer and Rich for administrative operations and PDT
+        (Pattern Day Trader) compliance tracking.
       </p>
     </section>
   </article>

--- a/src/pages/projects/smallcaptrader/index.astro
+++ b/src/pages/projects/smallcaptrader/index.astro
@@ -104,8 +104,10 @@ const tech = ['Python', 'FastAPI', 'Next.js', 'React', 'TypeScript', 'PostgreSQL
         <li><strong>Discovered Rules</strong> — Automatisch geschürfte Strategien aus der Rule-Mining-Engine, nach Validierung zum Live-Trading befördert</li>
       </ul>
       <p>
-        Jede Strategie enthält konfigurierbare Risikoparameter, Signal-Konfidenz-Scoring und prioritätsbasierte
-        Arbitrierung, wenn mehrere Strategien gleichzeitig für dasselbe Symbol auslösen.
+        Jede Strategie enthält konfigurierbare Risikoparameter, Signal-Konfidenz-Scoring, prioritätsbasierte
+        Arbitrierung wenn mehrere Strategien gleichzeitig für dasselbe Symbol auslösen, und
+        Erkennungstyp-Filterung, sodass Strategien nur bei passendem Aktienverhalten aktiviert werden
+        (schnelllaufend, langsamlaufend oder beides).
       </p>
     </section>
 
@@ -146,6 +148,33 @@ const tech = ['Python', 'FastAPI', 'Next.js', 'React', 'TypeScript', 'PostgreSQL
       </div>
 
       <div class="decision">
+        <h3>Unified Exit Engine</h3>
+        <p>
+          Zentralisierte Exit-Logik für Stop Loss, Trailing Stops, skalierte Gewinnziele und
+          zeitbasierte Exits. Jede Strategie und beförderte Regel kann ihre eigene Exit-Konfiguration
+          definieren, was feingranulares Risikomanagement ohne globales Fallback-Verhalten ermöglicht.
+        </p>
+      </div>
+
+      <div class="decision">
+        <h3>Kampagnen-Backtesting</h3>
+        <p>
+          Mehrtägige Strategievergleichs-Infrastruktur, die Performance über beliebige Datumsbereiche
+          aggregiert. Verteilte Ausführung via Redis Work Queues mit Per-Datum-Daten-Precaching.
+          Tagesübergreifende Aggregation zeigt Strategiekonsistenz, Gewinntage-Anzahl und
+          Parameterstabilität über längere Zeiträume.
+        </p>
+      </div>
+
+      <div class="decision">
+        <h3>Authentifizierung & Sicherheit</h3>
+        <p>
+          JWT-basierte Authentifizierung mit Access- und Refresh-Tokens. Geschützte API-Routen
+          erfordern Bearer-Tokens. Erweiterte Sitzungsunterstützung für persistenten Dashboard-Zugang.
+        </p>
+      </div>
+
+      <div class="decision">
         <h3>Observability Stack</h3>
         <p>
           Strukturiertes JSON-Logging via structlog, verteiltes Tracing mit OpenTelemetry und
@@ -160,8 +189,11 @@ const tech = ['Python', 'FastAPI', 'Next.js', 'React', 'TypeScript', 'PostgreSQL
       <p>
         Next.js 16-Dashboard mit React 19, Tailwind CSS v4 und shadcn/ui-Komponenten. TanStack
         Query für Server-State-Management. Zentrale Seiten umfassen Echtzeit-Portfolioüberwachung,
-        Orderaufgabe, Strategiekonfiguration, Backtest-Analytik mit Equity-Kurven und ein
-        Strategy-Discovery-Interface zur Visualisierung und Beförderung geschürfter Regeln.
+        Orderaufgabe, Strategiekonfiguration mit unabhängigen Fast/Slow-Erkennungs-Toggles,
+        Backtest-Analytik mit Equity-Kurven, Kampagnen-Backtesting für Mehrtagesvergleiche und ein
+        Strategy-Discovery-Interface zur Visualisierung und Beförderung geschürfter Regeln mit
+        Erkennungstyp-Tagging. Das Backend enthält zudem eine CLI auf Basis von Typer und Rich
+        für administrative Operationen sowie PDT (Pattern Day Trader) Compliance-Tracking.
       </p>
     </section>
   </article>


### PR DESCRIPTION
## Summary
- Update SmallCapTrader portfolio documentation to reflect current project state (exit engine, campaign backtesting, JWT auth, detection-type filtering, CLI tooling, distributed backtest workers, Polars)
- Fix i18n routing: English pages now correctly link to `/en/projects/...` instead of defaulting to German `/projects/...` routes

## Changes
- **DocSidebar, ProjectCard, Timeline** — use `getLocalePath()` for locale-aware links
- **SmallCapTrader docs (EN/DE)** — add missing features across overview, architecture, and component reference pages

Closes #1

## Test plan
- [x] Verify English project pages: sidebar Overview/Architecture/Components link to `/en/projects/...`
- [x] Verify German project pages: sidebar links stay as `/projects/...`
- [x] Verify Experience page "View Projects" links respect locale
- [x] Verify project card links on `/en/projects/` go to `/en/projects/...`
- [x] Review SmallCapTrader content for no leaked strategy specifics

🤖 Generated with [Claude Code](https://claude.com/claude-code)