### PR TITLE
Update SmallCapTrader docs and fix i18n link routing

### DIFF
--- a/src/content/projects/smallcaptrader/architecture.md
+++ b/src/content/projects/smallcaptrader/architecture.md
@@ -81,6 +81,10 @@ Stream Router ─── parses trades/bars
 | **Logging** | structlog | Structured JSON, async-safe |
 | **Data Processing** | Polars, Pandas, NumPy | High-performance analytics |
 | **CLI** | Typer + Rich | Administrative tooling |
+| **Type Checking** | MyPy (strict) | Static type safety |
+| **Testing** | pytest + hypothesis | Unit, integration, property-based |
+| **Dependency Management** | Renovate | Automated dependency updates |
+| **CI/CD** | GitHub Actions | Lint, typecheck, test on every push/PR |
 | **Observability** | OpenTelemetry + Prometheus | Distributed tracing, metrics |
 
 ### Frontend Stack

--- a/src/content/projects/smallcaptrader/components.md
+++ b/src/content/projects/smallcaptrader/components.md
@@ -184,3 +184,13 @@ Multi-day strategy comparison infrastructure:
 ## CLI Tooling
 
 Administrative command-line interface built with Typer and Rich for database management, service control, and operational tasks.
+
+---
+
+## Code Quality & CI/CD
+
+- **Linting** — Ruff for unified formatting and lint checks
+- **Type Checking** — MyPy in strict mode across the entire backend
+- **Testing** — pytest with async support, property-based testing (hypothesis), time mocking, and HTTP mocking
+- **CI Pipeline** — GitHub Actions runs lint, typecheck, and full test suite on every push and pull request
+- **Dependency Management** — Renovate for automated dependency updates with CI gating

--- a/src/content/projects/smallcaptrader/de/architecture.md
+++ b/src/content/projects/smallcaptrader/de/architecture.md
@@ -81,6 +81,10 @@ Stream Router ─── parses trades/bars
 | **Logging** | structlog | Strukturiertes JSON, async-sicher |
 | **Datenverarbeitung** | Polars, Pandas, NumPy | Hochperformante Analytik |
 | **CLI** | Typer + Rich | Administrative Werkzeuge |
+| **Type Checking** | MyPy (strikt) | Statische Typsicherheit |
+| **Testing** | pytest + hypothesis | Unit-, Integrations-, Property-basierte Tests |
+| **Dependency Management** | Renovate | Automatisierte Abhängigkeitsaktualisierungen |
+| **CI/CD** | GitHub Actions | Lint, Typecheck, Tests bei jedem Push/PR |
 | **Observability** | OpenTelemetry + Prometheus | Distributed Tracing, Metriken |
 
 ### Frontend-Stack

--- a/src/content/projects/smallcaptrader/de/components.md
+++ b/src/content/projects/smallcaptrader/de/components.md
@@ -184,3 +184,13 @@ Mehrtägige Strategievergleichs-Infrastruktur:
 ## CLI-Werkzeuge
 
 Administrative Kommandozeilen-Schnittstelle auf Basis von Typer und Rich für Datenbankverwaltung, Service-Steuerung und operationelle Aufgaben.
+
+---
+
+## Codequalität & CI/CD
+
+- **Linting** — Ruff für vereinheitlichte Formatierung und Lint-Prüfungen
+- **Type Checking** — MyPy im strikten Modus über das gesamte Backend
+- **Testing** — pytest mit Async-Unterstützung, Property-basiertes Testing (hypothesis), Zeit-Mocking und HTTP-Mocking
+- **CI-Pipeline** — GitHub Actions führt Lint, Typecheck und vollständige Test-Suite bei jedem Push und Pull Request aus
+- **Dependency Management** — Renovate für automatisierte Abhängigkeitsaktualisierungen mit CI-Gating


### PR DESCRIPTION
## Summary
- Update SmallCapTrader portfolio documentation to reflect current project state (exit engine, campaign backtesting, JWT auth, detection-type filtering, CLI tooling, distributed backtest workers, Polars, CI/CD pipeline, Renovate, code quality tooling)
- Fix i18n routing: English pages now correctly link to `/en/projects/...` instead of defaulting to German `/projects/...` routes

## Changes
- **DocSidebar, ProjectCard, Timeline** — use `getLocalePath()` for locale-aware links
- **SmallCapTrader docs (EN/DE)** — add missing features across overview, architecture, and component reference pages
- **Architecture tables** — add MyPy, pytest, hypothesis, Renovate, GitHub Actions
- **Component reference** — new Code Quality & CI/CD section

Closes #1

## Test plan
- [x] Verify English project pages: sidebar links go to `/en/projects/...`
- [x] Verify German project pages: sidebar links stay as `/projects/...`
- [x] Verify Experience page "View Projects" links respect locale
- [x] Verify project card links on `/en/projects/` go to `/en/projects/...`
- [x] Review SmallCapTrader content for no leaked strategy specifics

🤖 Generated with [Claude Code](https://claude.com/claude-code)