### PR TITLE
feat: sync SmallCapTrader portfolio with PRs #20, #26-#29, #31

### DIFF
--- a/src/content/projects/smallcaptrader/components.md
+++ b/src/content/projects/smallcaptrader/components.md
@@ -34,6 +34,17 @@ When multiple strategies fire on the same symbol simultaneously:
 
 ---
 
+## Indicator Engine
+
+Shared indicator computation infrastructure used by both live trading strategies and the rule-mining engine:
+
+- **Declarative Registry** — Each indicator field is registered with its dependencies, enabling automatic topological ordering and correct computation sequencing
+- **Incremental Append Engine** — New market data bars are processed in constant time per bar, maintaining real-time indicator state without full recomputation
+- **Demand-Based Evaluation** — Only indicators actually needed by the active strategy or mining run are computed, avoiding unnecessary work
+- **Shared Cache** — Computed indicator state is cached and reused across strategies and rule-mining runs within the same session
+
+---
+
 ## Rule Mining Engine
 
 Automated strategy discovery using a multi-phase beam search:
@@ -42,6 +53,7 @@ Automated strategy discovery using a multi-phase beam search:
 
 The engine progressively builds trading rules through a phased search process:
 
+0. **ML Seeding (Optional)** — A LightGBM model trains on historical trade data, extracts decision paths as seed candidates, and pre-selects promising condition combinations for the beam search to refine
 1. **Condition Screening** — Evaluates individual indicator conditions across multiple categories (price-based, temporal indicators, event flags)
 2. **Condition Combination** — Progressively combines top-performing conditions into multi-condition rules, pruning at each stage
 3. **Exit Optimization** — Grid search across risk parameters (stop loss, trailing stop, profit targets, max hold time) to find optimal exit configurations per rule
@@ -53,6 +65,10 @@ The engine progressively builds trading rules through a phased search process:
 - **Walk-forward cross-validation** to ensure rules generalize beyond training data
 - **Trade-set deduplication** to remove redundant rules that trigger on the same opportunities
 - **Suspicion scoring** to penalize rules that appear too good to be true
+
+### Exit Quality Scoring
+
+An alternative scoring mode that evaluates rules by exit behavior rather than aggregate P&L alone. A composite score weighs multiple dimensions — P&L, drawdown, hold efficiency, exit type quality, and peak-to-exit giveback — to surface rules that exit well, not just rules that profit. A scoring mode selector lets users choose between P&L-centric and exit quality-centric evaluation during discovery runs.
 
 ### Rule Lifecycle
 
@@ -113,7 +129,7 @@ Abstract `BaseBroker` interface enables seamless switching via configuration.
 Distributed backtesting with parameter optimization:
 
 - Sweeps parameter combinations across all strategies in parallel
-- Dedicated backtest workers in sharded mode for distributed execution via Redis work queues
+- Backtest and rule-mining workloads are fully offloaded to dedicated workers via Redis work queues, with a finalize queue handling asynchronous result aggregation separately from the API process
 - Tick data replay from QuestDB enables high-fidelity backtesting against historical market conditions
 - Results stored with per-strategy analytics
 - Best-performing configurations can be applied to live trading
@@ -147,6 +163,7 @@ Multi-day strategy comparison infrastructure:
 | **Strategy Discovery** | Rule mining UI, temporal pattern visualization, promote rules with detection-type tagging |
 | **Position Monitor** | Live exit state tracking, stop distances, profit target progress, WebSocket updates |
 | **Rule Lifecycle** | Health scoring, degradation detection, survival analysis, rule demotion |
+| **Trade Detail** | Decision audit trail with entry/exit conditions, indicator snapshots, candlestick visualization |
 | **Settings** | Risk management, notifications, broker config, scheduler |
 
 ---

--- a/src/content/projects/smallcaptrader/de/components.md
+++ b/src/content/projects/smallcaptrader/de/components.md
@@ -34,6 +34,17 @@ Wenn mehrere Strategien gleichzeitig für dasselbe Symbol auslösen:
 
 ---
 
+## Indicator Engine
+
+Gemeinsame Indikator-Berechnungsinfrastruktur, die sowohl von Live-Trading-Strategien als auch von der Rule-Mining-Engine genutzt wird:
+
+- **Deklarative Registry** — Jedes Indikatorfeld wird mit seinen Abhängigkeiten registriert, was automatische topologische Ordnung und korrekte Berechnungsreihenfolge ermöglicht
+- **Inkrementelle Append-Engine** — Neue Marktdaten-Bars werden in konstanter Zeit pro Bar verarbeitet, Echtzeit-Indikatorstatus ohne vollständige Neuberechnung
+- **Bedarfsbasierte Auswertung** — Nur tatsächlich von der aktiven Strategie oder dem Mining-Lauf benötigte Indikatoren werden berechnet, unnötige Arbeit wird vermieden
+- **Shared Cache** — Berechneter Indikatorstatus wird gecacht und über Strategien und Rule-Mining-Läufe innerhalb derselben Sitzung wiederverwendet
+
+---
+
 ## Rule Mining Engine
 
 Automatisierte Strategieentdeckung mittels mehrstufiger Beam-Suche:
@@ -42,6 +53,7 @@ Automatisierte Strategieentdeckung mittels mehrstufiger Beam-Suche:
 
 Die Engine baut schrittweise Handelsregeln durch einen phasenweisen Suchprozess auf:
 
+0. **ML Seeding (Optional)** — Ein LightGBM-Modell trainiert auf historischen Trade-Daten, extrahiert Decision Paths als Seed-Kandidaten und selektiert vielversprechende Bedingungskombinationen für die Beam-Suche vor
 1. **Bedingungsscreening** — Bewertet einzelne Indikatorbedingungen über mehrere Kategorien (preisbasiert, temporale Indikatoren, Event-Flags)
 2. **Bedingungskombination** — Kombiniert progressiv die Top-Performer zu Multi-Bedingungsregeln, Pruning in jeder Stufe
 3. **Exit-Optimierung** — Grid Search über Risikoparameter (Stop Loss, Trailing Stop, Gewinnziele, maximale Haltedauer) zur Findung optimaler Exit-Konfigurationen pro Regel
@@ -53,6 +65,10 @@ Die Engine baut schrittweise Handelsregeln durch einen phasenweisen Suchprozess 
 - **Walk-Forward-Kreuzvalidierung** zur Sicherstellung, dass Regeln über Trainingsdaten hinaus generalisieren
 - **Trade-Set-Deduplizierung** zur Entfernung redundanter Regeln, die bei denselben Gelegenheiten auslösen
 - **Verdachts-Scoring** zur Bestrafung von Regeln, die zu gut erscheinen, um wahr zu sein
+
+### Exit Quality Scoring
+
+Ein alternativer Scoring-Modus, der Regeln nach Exit-Verhalten statt ausschliesslich nach aggregiertem PnL bewertet. Ein zusammengesetzter Score gewichtet mehrere Dimensionen — PnL, Drawdown, Halteeffizienz, Exit-Typ-Qualität und Peak-to-Exit-Rückgabe — um Regeln zu identifizieren, die gut aussteigen, nicht nur Regeln, die profitieren. Ein Scoring-Modus-Selektor ermöglicht die Wahl zwischen PnL-zentrierter und Exit-Quality-zentrierter Auswertung während Discovery-Läufen.
 
 ### Regellebenszyklus
 
@@ -113,7 +129,7 @@ Abstraktes `BaseBroker`-Interface ermöglicht nahtlosen Wechsel via Konfiguratio
 Verteiltes Backtesting mit Parameteroptimierung:
 
 - Durchläuft Parameterkombinationen über alle Strategien parallel
-- Dedizierte Backtest-Worker im Sharded-Modus für verteilte Ausführung via Redis Work Queues
+- Backtest- und Rule-Mining-Workloads werden vollständig an dedizierte Worker via Redis Work Queues ausgelagert, mit einer Finalize Queue für asynchrone Ergebnisaggregation getrennt vom API-Prozess
 - Tick-Daten-Replay aus QuestDB ermöglicht High-Fidelity-Backtesting gegen historische Marktbedingungen
 - Ergebnisse mit Per-Strategie-Analysen gespeichert
 - Bestperformende Konfigurationen können auf Live-Trading angewandt werden
@@ -147,6 +163,7 @@ Mehrtägige Strategievergleichs-Infrastruktur:
 | **Strategy Discovery** | Rule Mining UI, temporale Mustervisualisierung, Regelbeförderung mit Erkennungstyp-Tagging |
 | **Position Monitor** | Live-Exit-State-Tracking, Stop-Distanzen, Gewinnziel-Fortschritt, WebSocket-Updates |
 | **Rule Lifecycle** | Health Scoring, Degradationserkennung, Überlebensanalyse, Regel-Herabstufung |
+| **Trade Detail** | Entscheidungs-Audit-Trail mit Ein-/Ausstiegsbedingungen, Indikator-Snapshots, Candlestick-Visualisierung |
 | **Settings** | Risikomanagement, Benachrichtigungen, Broker-Konfiguration, Scheduler |
 
 ---

--- a/src/pages/en/projects/smallcaptrader/index.astro
+++ b/src/pages/en/projects/smallcaptrader/index.astro
@@ -126,16 +126,33 @@ const projectSchema = JSON.stringify({
       <h2>Key Technical Decisions</h2>
 
       <div class="decision">
+        <h3>Indicator Engine</h3>
+        <p>
+          The platform computes indicators once via a declarative registry with automatic
+          dependency resolution rather than each strategy computing its own. An incremental
+          append engine processes new market data in constant time per bar, enabling real-time
+          indicator state without full recomputation. Demand-based evaluation ensures only the
+          indicators needed by the active strategy or mining run are computed. The shared
+          indicator cache serves both live trading strategies and the rule-mining engine.
+        </p>
+      </div>
+
+      <div class="decision">
         <h3>Rule-Mining Engine (Beam Search)</h3>
         <p>
-          Automated strategy discovery using a multi-phase beam search approach. The engine
-          evaluates indicator conditions individually, then progressively combines top performers
-          into multi-condition rules. Exit parameters are optimized via grid search, and
-          multi-phase temporal patterns (sequential condition sequences with configurable timing)
-          are explored for complex market behaviors. Walk-forward cross-validation ensures
-          discovered rules generalize beyond training data. Rules that pass validation can be
-          promoted directly to live trading. Campaign infrastructure supports multi-day
-          automated discovery runs.
+          Automated strategy discovery using a multi-phase beam search. An optional ML seeding
+          phase trains a LightGBM model on historical trade data and extracts decision paths
+          as seed candidates, giving the beam search a head start on promising condition
+          combinations. The core engine then screens individual indicator conditions, progressively
+          combines top performers into multi-condition rules, and optimizes exit parameters via
+          grid search. Multi-phase temporal patterns explore sequential condition sequences with
+          configurable timing for complex market behaviors. Beyond traditional aggregate scoring,
+          an exit quality scoring mode evaluates rules by how well they exit — weighing P&L,
+          drawdown, hold efficiency, exit type quality, and peak-to-exit giveback — with a
+          scoring mode selector for P&L-centric or exit-quality-centric evaluation.
+          Walk-forward cross-validation ensures discovered rules generalize beyond training data.
+          Rules that pass validation can be promoted directly to live trading, with campaign
+          infrastructure supporting multi-day automated discovery runs.
         </p>
       </div>
 
@@ -152,6 +169,8 @@ const projectSchema = JSON.stringify({
         <h3>Auto-Backtest & Parameter Optimization</h3>
         <p>
           Distributed backtesting engine that sweeps parameter combinations across all strategies.
+          Backtest and rule-mining workloads are fully offloaded to dedicated workers, with
+          asynchronous result aggregation via a finalize queue keeping the API process lightweight.
           Results are stored and the best-performing configurations can be applied to live trading.
           Real-time progress streaming via WebSocket to the frontend dashboard. Tick data replay
           from QuestDB enables high-fidelity backtesting against historical market conditions.
@@ -215,13 +234,15 @@ const projectSchema = JSON.stringify({
     <section class="case-section" data-animate="slide-up">
       <h2>Frontend</h2>
       <p>
-        Next.js 16 dashboard with React 19, Tailwind CSS v4, and shadcn/ui components. TanStack
+        Next.js 16 dashboard with React 19, Tailwind CSS v4, and shadcn/ui components styled
+        with a Bloomberg Terminal-inspired dark theme for a professional trading aesthetic. TanStack
         Query for server state management. Key pages include real-time portfolio monitoring, order
         entry, strategy configuration with independent fast/slow detection toggles, backtest analytics
         with equity curves, campaign backtesting for multi-day comparison, a strategy discovery
         interface for visualizing and promoting mined rules with detection-type tagging, a live
-        position monitor with exit state tracking, and a rule lifecycle dashboard with health
-        scoring and degradation detection. The backend also includes a CLI built with Typer and
+        position monitor with exit state tracking, a rule lifecycle dashboard with health
+        scoring and degradation detection, and trade detail pages showing which conditions
+        triggered entry and exit decisions. The backend also includes a CLI built with Typer and
         Rich for administrative operations and PDT (Pattern Day Trader) compliance tracking.
       </p>
     </section>

--- a/src/pages/projects/smallcaptrader/index.astro
+++ b/src/pages/projects/smallcaptrader/index.astro
@@ -132,16 +132,35 @@ const projectSchema = JSON.stringify({
       <h2>Technische Schlüsselentscheidungen</h2>
 
       <div class="decision">
+        <h3>Indicator Engine</h3>
+        <p>
+          Die Plattform berechnet Indikatoren einmalig über eine deklarative Registry mit
+          automatischer Dependency Resolution, anstatt dass jede Strategie ihre eigenen berechnet.
+          Eine inkrementelle Append-Engine verarbeitet neue Marktdaten in konstanter Zeit pro Bar
+          und ermöglicht Echtzeit-Indikatorstatus ohne vollständige Neuberechnung. Bedarfsbasierte
+          Auswertung stellt sicher, dass nur die von der aktiven Strategie oder dem Mining-Lauf
+          benötigten Indikatoren berechnet werden. Der gemeinsame Indicator Cache dient sowohl
+          Live-Trading-Strategien als auch der Rule-Mining-Engine.
+        </p>
+      </div>
+
+      <div class="decision">
         <h3>Rule-Mining-Engine (Beam Search)</h3>
         <p>
-          Automatisierte Strategieentdeckung mittels mehrstufigem Beam-Search-Ansatz. Die Engine
-          bewertet Indikatorbedingungen einzeln, kombiniert dann progressiv die Top-Performer
-          zu Multi-Bedingungsregeln. Exit-Parameter werden via Grid Search optimiert und
-          mehrstufige Temporalmuster (sequenzielle Bedingungsfolgen mit konfigurierbarem Timing)
-          werden für komplexe Marktverhalten erkundet. Walk-Forward-Kreuzvalidierung stellt sicher,
-          dass entdeckte Regeln über die Trainingsdaten hinaus generalisieren. Regeln, die die
-          Validierung bestehen, können direkt zum Live-Trading befördert werden. Kampagnen-Infrastruktur
-          unterstützt mehrtägige automatisierte Entdeckungsläufe.
+          Automatisierte Strategieentdeckung mittels mehrstufiger Beam-Suche. Eine optionale
+          ML-Seeding-Phase trainiert ein LightGBM-Modell auf historischen Trade-Daten und
+          extrahiert Decision Paths als Seed-Kandidaten, wodurch die Beam-Suche einen Vorsprung
+          bei vielversprechenden Bedingungskombinationen erhält. Die Kern-Engine screent dann
+          einzelne Indikatorbedingungen, kombiniert progressiv Top-Performer zu Multi-Bedingungsregeln
+          und optimiert Exit-Parameter via Grid Search. Mehrstufige Temporalmuster erkunden
+          sequenzielle Bedingungsfolgen mit konfigurierbarem Timing für komplexe Marktverhalten.
+          Über das traditionelle aggregierte Scoring hinaus bewertet ein Exit-Quality-Scoring-Modus
+          Regeln danach, wie gut sie aussteigen — unter Gewichtung von PnL, Drawdown, Halteeffizienz,
+          Exit-Typ-Qualität und Peak-to-Exit-Rückgabe — mit einem Scoring-Modus-Selektor für
+          PnL-zentrierte oder Exit-Quality-zentrierte Auswertung. Walk-Forward-Kreuzvalidierung
+          stellt sicher, dass entdeckte Regeln über die Trainingsdaten hinaus generalisieren.
+          Regeln, die die Validierung bestehen, können direkt zum Live-Trading befördert werden,
+          mit Kampagnen-Infrastruktur für mehrtägige automatisierte Entdeckungsläufe.
         </p>
       </div>
 
@@ -158,9 +177,12 @@ const projectSchema = JSON.stringify({
         <h3>Auto-Backtest & Parameteroptimierung</h3>
         <p>
           Verteilte Backtesting-Engine, die Parameterkombinationen über alle Strategien durchläuft.
-          Ergebnisse werden gespeichert und die leistungsstärksten Konfigurationen können auf Live-Trading
-          angewendet werden. Echtzeit-Fortschrittsstreaming via WebSocket zum Frontend-Dashboard.
-          Tick-Daten-Replay aus QuestDB ermöglicht High-Fidelity-Backtesting gegen historische Marktbedingungen.
+          Backtest- und Rule-Mining-Workloads werden vollständig an dedizierte Worker ausgelagert,
+          mit asynchroner Ergebnisaggregation über eine Finalize Queue, die den API-Prozess
+          schlank hält. Ergebnisse werden gespeichert und die leistungsstärksten Konfigurationen
+          können auf Live-Trading angewendet werden. Echtzeit-Fortschrittsstreaming via WebSocket
+          zum Frontend-Dashboard. Tick-Daten-Replay aus QuestDB ermöglicht High-Fidelity-Backtesting
+          gegen historische Marktbedingungen.
         </p>
       </div>
 
@@ -222,14 +244,16 @@ const projectSchema = JSON.stringify({
     <section class="case-section" data-animate="slide-up">
       <h2>Frontend</h2>
       <p>
-        Next.js 16-Dashboard mit React 19, Tailwind CSS v4 und shadcn/ui-Komponenten. TanStack
-        Query für Server-State-Management. Zentrale Seiten umfassen Echtzeit-Portfolioüberwachung,
+        Next.js 16-Dashboard mit React 19, Tailwind CSS v4 und shadcn/ui-Komponenten, gestaltet
+        mit einem Bloomberg Terminal-inspirierten Dark Theme für eine professionelle Trading-Ästhetik.
+        TanStack Query für Server-State-Management. Zentrale Seiten umfassen Echtzeit-Portfolioüberwachung,
         Orderaufgabe, Strategiekonfiguration mit unabhängigen Fast/Slow-Erkennungs-Toggles,
         Backtest-Analytik mit Equity-Kurven, Kampagnen-Backtesting für Mehrtagesvergleiche, ein
         Strategy-Discovery-Interface zur Visualisierung und Beförderung geschürfter Regeln mit
-        Erkennungstyp-Tagging, ein Live-Positionsmonitor mit Exit-State-Tracking sowie ein
-        Rule-Lifecycle-Dashboard mit Health Scoring und Degradationserkennung. Das Backend enthält
-        zudem eine CLI auf Basis von Typer und Rich für administrative Operationen sowie PDT
+        Erkennungstyp-Tagging, ein Live-Positionsmonitor mit Exit-State-Tracking, ein
+        Rule-Lifecycle-Dashboard mit Health Scoring und Degradationserkennung sowie Trade-Detail-Seiten,
+        die zeigen, welche Bedingungen Ein- und Ausstiegsentscheidungen ausgelöst haben. Das Backend
+        enthält zudem eine CLI auf Basis von Typer und Rich für administrative Operationen sowie PDT
         (Pattern Day Trader) Compliance-Tracking.
       </p>
     </section>


### PR DESCRIPTION
## Summary

- Add **Indicator Engine** section and decision block — declarative registry, incremental O(1) computation, demand-based evaluation, shared cache
- Rewrite **Rule-Mining Engine** decision block — integrates ML seeding (LightGBM Phase 0), exit quality scoring (multi-dimension composite), and scoring mode selector
- Update **Backtest Engine** — distributed finalization pipeline with worker offload and async result aggregation
- Add **Trade Detail** page to Frontend Pages table — decision audit trail with entry/exit conditions
- Update **Frontend** section — Bloomberg Terminal-inspired dark theme, trade decision context
- All changes applied to both EN and DE versions

## Test plan

- [x] Site builds successfully (`npm run build` — 35 pages, no errors)
- [x] Verify EN overview page renders new Indicator Engine and rewritten Rule-Mining blocks
- [x] Verify DE overview page mirrors EN content structure
- [x] Verify EN/DE components.md shows Indicator Engine section, ML Seeding Phase 0, Exit Quality Scoring subsection, Trade Detail row
- [x] Verify no concrete numbers leaked into portfolio content

🤖 Generated with [Claude Code](https://claude.com/claude-code)